### PR TITLE
Fix sidebar icons for Spotify v1.1.78.765

### DIFF
--- a/user.css
+++ b/user.css
@@ -293,14 +293,14 @@ h3,
 
 /* buttons */
 
-.icon, .gSLhUO {
+.icon, .hDgDGI {
   -webkit-mask-repeat: no-repeat;
   -webkit-mask-position: center;
   margin: auto;
   display: block;
 }
 
-.main-navBar-navBarLink .gSLhUO path,
+.main-navBar-navBarLink .hDgDGI path,
 .icon > svg,
 .x-searchInput-searchInputIconContainer path,
 .show-episodeBlock-playerActions svg, 
@@ -541,7 +541,7 @@ button.switch {
 }
 
 .main-navBar-navBarLinkActive > .icon,
-.main-navBar-navBarLinkActive .gSLhUO {
+.main-navBar-navBarLinkActive .hDgDGI {
   position: relative;
   top: 50%;
   transform: translate(0, -50%);
@@ -1311,7 +1311,7 @@ option {
 }
 
 .main-connectBar-connectBar .icon, 
-.main-connectBar-connectBar .gSLhUO {
+.main-connectBar-connectBar .hDgDGI {
   margin: 0px;
   margin-right: 8px;
 }


### PR DESCRIPTION
Fixes #22 

Before / After

![image](https://user-images.githubusercontent.com/17136956/154473753-d4ccaa25-9f91-49e4-a499-7420c311a8c4.png) ![image](https://user-images.githubusercontent.com/17136956/154473806-93dba39c-be4d-4848-bb83-3d7c612f5e48.png) 
![image](https://user-images.githubusercontent.com/17136956/154474112-e965d480-81da-488a-9a54-16207c29fabe.png)

**Note:** The navigation button fixes on the top left were fixed by somewhere between spicetify-cli v2.8.3 and v2.9.0, not by this pull request.