### PR TITLE
Fix spacing symmetry on Playlist Add icon

### DIFF
--- a/user.css
+++ b/user.css
@@ -358,7 +358,7 @@ h3,
   width: 24px !important;
   display: block !important; 
   margin-top: 20px !important;
-  margin-bottom: 10px !important;
+  margin-bottom: 20px !important;
 }
 
 .main-createPlaylistButton-button svg {


### PR DESCRIPTION
Before / After
![before](https://user-images.githubusercontent.com/17136956/154476545-3e35a92e-517e-4f56-ab7b-3c8d768eee2f.png) ![after](https://user-images.githubusercontent.com/17136956/154476555-cdd7562c-18b2-44e3-b613-93a662542cd1.png)

As you can see, it's now more accurate to the original images seen in the README, yet still better as the margin-top seems too large in the README example:
![image](https://user-images.githubusercontent.com/17136956/154476658-c70885ea-91b4-4b0d-90e0-4fac4b160257.png)
