### PR TITLE
Fix the sidebar's top-padding to fix Home button's corner radius

### DIFF
--- a/user.css
+++ b/user.css
@@ -553,7 +553,7 @@ button.switch {
 }
 
 .main-navBar-entryPoints {
-  padding-top: 36px !important;
+  padding-top: 40px !important;
 }
 
 .main-type-mestoBold {


### PR DESCRIPTION
Before / After:
![image](https://user-images.githubusercontent.com/17136956/154489869-65b6ba72-6808-4be8-877b-cc22402b45f5.png) ![image](https://user-images.githubusercontent.com/17136956/154489938-9f2d433d-142c-4e72-8bf0-902f8e286e09.png)

This also helps align the start of the sidebar's items, to the start/top edge of the main content area.