### PR TITLE
Various font fixes

### DIFF
--- a/user.css
+++ b/user.css
@@ -99,11 +99,6 @@
 
 /* cards */
 
-.main-shelf-shelfGrid,
-.view-homeShortcutsGrid-grid {
-  overflow: visible;
-}
-
 .main-cardImage-image,
 .main-cardImage-imageWrapper,
 .OALAQFKvC7XQOVYpklB4 img {
@@ -186,7 +181,6 @@
 .main-entityHeader-title {
   font-size: unset;
   font-weight: 500;
-  overflow: visible !important;
 }
 
 h1,
@@ -200,7 +194,6 @@ h3,
 .x-searchResultsTracks-title {
   font-weight: 500;
   letter-spacing: 0.1px !important;
-  overflow: visible !important;
   margin-bottom: 4px;
   white-space: normal;
 }
@@ -537,7 +530,6 @@ button.switch {
 
 .main-navBar-navBarLink span,
 .main-createPlaylistButton-text {
-  overflow: visible;
   font-size: 10.5px !important;
   margin: auto;
   display: block;
@@ -1217,10 +1209,6 @@ path[d="M23 0C10.298 0 0 10.297 0 23c0 12.702 10.298 23 23 23 12.703 0 23-10.298
   max-width: 190px;
 }
 
-.profile-userOverview-section .main-shelf-shelfGrid {
-  overflow: hidden;
-}
-
 /* settings */
 
 .main-dropDown-dropDown,
@@ -1362,7 +1350,6 @@ option {
 
 .prog-tooltip {
   width: 140px;
-  overflow: hidden;
   display: none;
 }
 

--- a/user.css
+++ b/user.css
@@ -131,7 +131,6 @@
 }
 
 .main-tag-container {
-  font-family: "Segoe UI", sans-serif !important;
   font-weight: 400;
   font-size: 10px;
   color: #463d3d !important;
@@ -186,7 +185,6 @@
 
 .main-entityHeader-title {
   font-size: unset;
-  font-family: 'Segoe UI', sans-serif !important;
   font-weight: 500;
   overflow: visible !important;
 }
@@ -200,7 +198,6 @@ h3,
 .main-type-bass,
 .main-cardHeader-text.main-type-alto,
 .x-searchResultsTracks-title {
-  font-family: 'Segoe UI', sans-serif !important;
   font-weight: 500;
   letter-spacing: 0.1px !important;
   overflow: visible !important;
@@ -421,7 +418,6 @@ h3,
 
 
 .main-type-balladBold {
-  font-family: 'Segoe UI', sans-serif !important;
   font-weight: 500;
   letter-spacing: 0.2px;
 }
@@ -475,7 +471,6 @@ button.switch {
 .main-buttons-button,
 .show-followButton-button {
   background-color: var(--spice-card);
-  font-family: "Segoe UI", sans-serif;
   font-weight: normal;
   font-size: 15px;
   letter-spacing: 0px;
@@ -574,7 +569,6 @@ button.switch {
 }
 
 .main-type-mestoBold {
-  font-family: 'Segoe UI', sans-serif !important;
   font-weight: normal !important;
 }
 
@@ -938,7 +932,6 @@ button.switch {
 .main-entityHeader-topbarTitle,
 .main-topBar-topbarTitle {
   font-size: 16px;
-  font-family: 'Segoe UI', sans-serif !important;
   font-weight: 400;
   padding-left: 4px;
   position: relative;

--- a/user.css
+++ b/user.css
@@ -421,7 +421,7 @@ h3,
   letter-spacing: 0px;
   font-weight: 400;
   font-size: 14px;
-  line-height: 0px;
+  line-height: 10px;
 }
 
 .main-shelf-seeAll {

--- a/user.css
+++ b/user.css
@@ -13,6 +13,7 @@
 
 * {
   font-family: 'Segoe UI', sans-serif !important;
+  line-height: normal;
   box-shadow: none !important;
   -webkit-mask-repeat: no-repeat;
   -webkit-mask-position: center;


### PR DESCRIPTION
This seems to, at least on my end, fix #11.

However, some references to text elements I was not able to locate in the app, so I could not fully test.
Regardless, the result is more consistent overall.

Before:

![image](https://user-images.githubusercontent.com/17136956/154636152-96d1ec66-fa90-454b-8438-d4d01bfe930f.png)

After:

![image](https://user-images.githubusercontent.com/17136956/154636079-073c650f-4fcf-47b3-9b15-d9688dc41c14.png)

(pay attention to the `Playlist` minuet text under AAAAAAAAA... as well as `Songs`, the `g` is no longer clipped.)

* * *

While the before/after may look like only one or two clips and overflows were fixed, the actual end result is much more consistent across the UI. For one, all overflow specifications were removed entirely and instead text clips were fixed properly via a line-height specification.

This makes all text across the board correct, but its positioning may now be ever so slightly altered. If you compare the before/after pics closely, you can see text everywhere has changed ever so slightly in position in relatively unpredictable ways, but it does look correct on my end.
