### PR TITLE
Playlist items

### DIFF
--- a/user.css
+++ b/user.css
@@ -665,6 +665,11 @@ button.switch {
   padding: 8px;
   right: -17px;
   top: -8px;
+  transform: rotate(-90deg);
+}
+
+.main-rootlist-expandArrow.qAAhQw9dXNB7DbPgDDxy {
+  transform: rotate(0deg);
 }
 
 .main-rootlist-statusIcons {

--- a/user.css
+++ b/user.css
@@ -614,6 +614,13 @@ button.switch {
 }
 
 
+/* sidebar resizer */
+
+.LayoutResizer__resize-bar {
+  display: none;
+}
+
+
 /* playlist sidebar */
 
 .main-rootlist-rootlist .os-content {

--- a/user.css
+++ b/user.css
@@ -389,7 +389,7 @@ h3,
   width: 49px;
   min-height: 48px;
   margin: auto;
-  margin-bottom: 14px;
+  margin-bottom: 8px;
   justify-content: center;
 }
 
@@ -644,8 +644,11 @@ button.switch {
   background-color: var(--spice-card);
   background-size: cover;
   border-radius: var(--border-radius-2);
-  margin-bottom: 14px;
   cursor: pointer;
+}
+
+.main-rootlist-rootlistItemLink:not(:last-child) {
+  margin-bottom: 8px;
 }
 
 .main-rootlist-textWrapper {

--- a/user.css
+++ b/user.css
@@ -661,10 +661,10 @@ button.switch {
 .main-rootlist-expandArrow {
   color: var(--spice-text);
   position: relative;
-  margin-inline-start: -32px;
-  padding: 8px;
-  right: -17px;
-  top: -8px;
+  margin-inline-start: -16px;
+  right: -6px;
+  top: 16px;
+  height: 16px;
   transform: rotate(-90deg);
 }
 

--- a/user.css
+++ b/user.css
@@ -664,7 +664,7 @@ button.switch {
   margin-inline-start: -32px;
   padding: 8px;
   right: -17px;
-  top: -1px;
+  top: -8px;
 }
 
 .main-rootlist-statusIcons {

--- a/user.css
+++ b/user.css
@@ -658,12 +658,6 @@ button.switch {
   top: -4px;
 }
 
-.main-rootlist-rootlistItemLinkActive~.main-rootlist-expandArrow:focus,
-.main-rootlist-rootlistItemLinkActive~.main-rootlist-expandArrow:hover,
-.main-rootlist-rootlistItemLinkActive~.main-rootlist-expandArrow {
-  color: var(--spice-text);
-}
-
 .main-rootlist-expandArrow {
   color: var(--spice-text);
   position: relative;
@@ -671,11 +665,6 @@ button.switch {
   padding: 8px;
   right: -17px;
   top: -1px;
-}
-
-.main-rootlist-expandArrowRotated {
-  right: -5px !important;
-  top: 14px !important;
 }
 
 .main-rootlist-statusIcons {

--- a/user.css
+++ b/user.css
@@ -638,6 +638,7 @@ button.switch {
   background-size: cover;
   border-radius: var(--border-radius-2);
   margin-bottom: 14px;
+  cursor: pointer;
 }
 
 .main-rootlist-textWrapper {


### PR DESCRIPTION
- Added cursor: pointer to the playlist images in sidebar to feel like a button.
- Removed the sidebar resizer, best to remove it if it isn't going to be supported.
- Removed unnecessary/bad CSS on Folder Arrows
- Improved CSS for Folder Arrows, fixing rotation and spacing/alignment.

## Reduced Margin between Playlists

Before:

![image](https://user-images.githubusercontent.com/17136956/154712497-9e604b2e-e43c-491d-8c86-c2a50a660c6e.png)

After:

![image](https://user-images.githubusercontent.com/17136956/154712442-617e1b68-5da6-4883-a12e-9ae593432c09.png)

As you can see, without this change the hardcoded height of the playlist sidebar area wont be large enough to support a long amount of playlists. The margin was simply too much. It's possible that an even larger amount could diminish the amount of height usable, but this is a step in the right direction.

When making this change I've also reduced the margin between the library (likes/podcasts) down to the same amount as well to keep consistency.

This fixes #19 