### PR TITLE
Don't let playlist list go below player controls

### DIFF
--- a/user.css
+++ b/user.css
@@ -643,6 +643,7 @@ button.switch {
   --left-sidebar-item-height: 48px;
   --left-sidebar-padding-left: 18px;
   --left-sidebar-padding-right: 18px;
+  padding-bottom: 120px;  /* don't go below player controls */
 }
 
 .main-rootlist-rootlistItemLink {


### PR DESCRIPTION
A padding-bottom of 120px seems to be the perfect amount.

Fixes #41 without compromising on the rounded corner border.

Before:

![image](https://user-images.githubusercontent.com/17136956/154852340-b432b046-566e-4284-96a1-436944badce3.png)

After:

![image](https://user-images.githubusercontent.com/17136956/154852322-4c75a4f2-04b8-4196-8f7d-5633c2a9242f.png)
