### PR TITLE
Fix horizontal alignment of Sticky Header, remove rectangles from sides

### DIFF
--- a/user.css
+++ b/user.css
@@ -801,6 +801,7 @@ button.switch {
 .main-trackList-trackListHeaderStuck.main-trackList-trackListHeader {
   border-bottom: none;
   background: none;
+  margin: auto;
   padding: 0;
 }
 

--- a/user.css
+++ b/user.css
@@ -800,6 +800,8 @@ button.switch {
 
 .main-trackList-trackListHeaderStuck.main-trackList-trackListHeader {
   border-bottom: none;
+  background: none;
+  padding: 0;
 }
 
 .main-trackList-statusChangeUp {


### PR DESCRIPTION
This patch is similar to #57 but does the job more effectively.
I've confirmed this patch to do the job no matter how wide the window is. The alignment of the header columns also match without any manual adjustment to a column as well.

Before:

![Before](https://user-images.githubusercontent.com/17136956/162635766-af042652-4943-48ed-911a-604a68c3a25b.png)

After:
![After](https://user-images.githubusercontent.com/17136956/162635754-5331e304-fa8a-49b1-8113-10c4a3d7edbd.png)
